### PR TITLE
Support inotify to watch crontab directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *.swp
 protos.h
+*.o
+crond
+crontab
+config

--- a/database.c
+++ b/database.c
@@ -18,6 +18,7 @@
 #define ALL_DOW    (FIRST_DOW|SECOND_DOW|THIRD_DOW|FOURTH_DOW|FIFTH_DOW|LAST_DOW)
 
 Prototype void CheckUpdates(const char *dpath, const char *user_override, time_t t1, time_t t2);
+Prototype void CheckFile(const char *dpath, const char *fileName, const char *user_override);
 Prototype void SynchronizeDir(const char *dpath, const char *user_override, int initial_scan);
 Prototype void ReadTimestamps(const char *user);
 Prototype int TestJobs(time_t t1, time_t t2);
@@ -216,18 +217,7 @@ SynchronizeDir(const char *dpath, const char *user_override, int initial_scan)
 	 */
 	if ((dir = opendir(dpath)) != NULL) {
 		while ((den = readdir(dir)) != NULL) {
-			if (strchr(den->d_name, '.') != NULL)
-				continue;
-			if (strcmp(den->d_name, CRONUPDATE) == 0)
-				continue;
-			if (user_override) {
-				SynchronizeFile(dpath, den->d_name, user_override);
-			} else if (getpwnam(den->d_name)) {
-				SynchronizeFile(dpath, den->d_name, den->d_name);
-			} else {
-				printlogf(LOG_WARNING, "ignoring %s/%s (non-existent user)\n",
-						dpath, den->d_name);
-			}
+			CheckFile(dpath, den->d_name, user_override);
 		}
 		closedir(dir);
 	} else {
@@ -237,6 +227,22 @@ SynchronizeDir(const char *dpath, const char *user_override, int initial_scan)
 	}
 }
 
+void
+CheckFile(const char *dpath, const char *fileName, const char *user_override)
+{
+	if (strchr(fileName, '.') != NULL)
+		return;
+	if (strcmp(fileName, CRONUPDATE) == 0)
+		return;
+	if (user_override) {
+		SynchronizeFile(dpath, fileName, user_override);
+	} else if (getpwnam(fileName)) {
+		SynchronizeFile(dpath, fileName, fileName);
+	} else {
+		printlogf(LOG_WARNING, "ignoring %s/%s (non-existent user)\n",
+				dpath, fileName);
+	}
+}
 
 void
 ReadTimestamps(const char *user)

--- a/defs.h
+++ b/defs.h
@@ -45,6 +45,11 @@
 #include <string.h>
 #include <stdio.h>
 
+#ifdef USE_INOTIFY
+#include <poll.h>
+#include <sys/inotify.h>
+#endif
+
 #define Prototype extern
 #define arysize(ary)	(sizeof(ary)/sizeof((ary)[0]))
 


### PR DESCRIPTION
If compiled with `make CPPFLAGS=-DUSE_INOTIFY`, then `crond` will now monitor both crontab directories, and will immediately synchronize any files right after they have been closed or deleted. So far this feature is completely undocumented. I gave it a tiny bit of testing, and it appears to work well enough. I haven't attempted to verify all the error code paths, since for most of the errors I don't even know how to deliberately trigger them.

This change may lead to crontabs being re-read twice, once triggered by inotify and a second time by `cron.update`.  This should be no serious problem, though.

The code is heavily based on [the example in the inotify man page](http://man7.org/linux/man-pages/man7/inotify.7.html#EXAMPLE). On the other hand, except for choosing different names for variables, there probably isn't much room to do things very different from this, so I'm not sure whether we'd have to add a notice to credit [the man page authors](http://man7.org/linux/man-pages/man7/inotify.7.license.html) in accordance with the man page license. Come to think of it, the dcron code should probably specify what version of the GPL to apply.