### PR TITLE
Patch 2

### DIFF
--- a/main.c
+++ b/main.c
@@ -355,7 +355,11 @@ main(int ac, char **av)
 				if (CheckJobs() > 0)
 					stime = 10;
 				else
-					stime = 60;
+					/* Used to be 60 but this skips aminute when,
+					 * time is at :55 because of sleep(5), which happens
+					 * on heavy filesystem load.
+					 */
+					stime = 30;
 				t1 = t2;
 			}
 		}

--- a/main.c
+++ b/main.c
@@ -338,7 +338,8 @@ main(int ac, char **av)
 					SynchronizeDir(SCDir, "root", 0);
 					ReadTimestamps(NULL);
 				}
-			} else {
+			}
+			if (rescan < 60) {
 				CheckUpdates(CDir, NULL, t1, t2);
 				CheckUpdates(SCDir, "root", t1, t2);
 			}


### PR DESCRIPTION
Avoid skipping a minute when system is under heavy load.

In fact this is just a hack on a weird part of code. I would expect this to work by calculating the number of seconds until the next minute just before the end of the loop, and then wait that calculated time directly after that. But this is not how the code works. Somehow this is done in the code by getting the current time at the start of the loop. Then, while in the loop, stuff happens (which takes time) and even a sleep(5) is done, but none of this is accounted for in the calculation of the sleep-time.

Maybe I am missing something, so I just lowered the (large) wait-time. Theoretically, the same thing can still happen if the calls in the loop take more than 30 seconds, but we'll settle for that.