### PR TITLE
database: indented lines are not enclosed

### DIFF
--- a/database.c
+++ b/database.c
@@ -265,11 +265,12 @@ ReadTimestamps(const char *user)
 							}
 							sec = (time_t)-1;
 							ptr = strptime(ptr, CRONSTAMP_FMT, &tm);
-							if (ptr && (*ptr == 0 || *ptr == '\n'))
+							if (ptr && (*ptr == 0 || *ptr == '\n')) {
 								/* strptime uses current seconds when seconds not specified? anyway, we don't get round minutes */
 								tm.tm_sec = 0;
 								tm.tm_isdst = -1;
 								sec = mktime(&tm);
+							}
 							if (sec == (time_t)-1) {
 								printlogf(LOG_ERR, "unable to parse timestamp (user %s job %s)\n", file->cf_UserName, line->cl_JobName);
 								/* we continue checking other timestamps in this CronFile */


### PR DESCRIPTION
Based from the history it seems someone forget to enclose code to brackets